### PR TITLE
Adding organisation README, ITS-23846

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default all changes will request review from:
+* @rhysfaultless-cpr @jhiggins-cpr @tonybaltovski

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+This repository needs to remain public to adhere to [GitHub's guide of adding an organization README](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile#adding-a-public-organization-profile-readme).
+GitHub displays the contents of the file `/profile/README.md` on the overview page of the organisation.
+
+To update the overview page of the organisation:
+
+1.  Clone this repository.
+2.  Create a branch.
+3.  Make updates to the file `/profile/README.md`.
+    Images should be stored in the directory `/images`.
+4.  Push your changes, and submit a pull request.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,22 @@
+## Get Involved
+
+Fork one of our public repositories and submit a Pull Request describing the suggested change.
+The repository's maintainer will review the proposed change.
+
+## Get Added As A Member
+
+Organisation members can view private repositories, and can use branches instead of forks for making updates.
+If you are an employee, submit a Jira ticket to IT, which says you want to be added to this organization as a member.
+If you are not an employee but think you need access to our private repositories, reach out to our Support or Sales teams from the links mentioned in the [Help](#help) section below.
+
+## Help
+
+Consider going to our websites if you need help with your robot, have a potential project, or want to work with us.
+
+- [clearpathrobotics.com](https://clearpathrobotics.com)
+- [ottomotors.com](https://ottomotors.com/)
+
+If you are looking for user manuals and tutorials for our products:
+
+- [docs.clearpathrobotics.com](https://docs.clearpathrobotics.com)
+- [docs.ottomotors.com](https://docs.ottomotors.com)


### PR DESCRIPTION
This change will add a README to the overview of [clearpathrobotics](https://github.com/clearpathrobotics).
This change is to support the organisation changes detailed in [ITS-23846](https://jira.clearpathrobotics.com/browse/ITS-23846).

Refer to [Microsoft's organisation](https://github.com/microsoft) for a reference structure.